### PR TITLE
Auto-install requirements via pip, add GitHub workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest black
+    - name: Lint with flake8
+      run: |
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --exit-zero --statistics
+    - name: Check formatting
+      run: |
+        black grg_pheno_sim/ setup.py --check
+    #- name: Test with pytest
+    #  run: |
+    #    PYTHONPATH=$PWD pytest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__
 demos/*/*.phen
 demos/*/*.par
 *.egg-info
+.ipynb_checkpoints
+*.swp
+build/
+dist/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numba>=0.60.0
 numpy>=2.2.0
 pandas>=2.2.3
 pygrgl>=1.2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 from setuptools import setup, find_packages
+import os
 
 PACKAGE_NAME = "grg_pheno_sim"
 VERSION = "1.0"
+
+THISDIR = os.path.dirname(os.path.realpath(__file__))
+with open(os.path.join(THISDIR, "requirements.txt")) as f:
+    requirements = list(map(str.strip, f))
 
 setup(
     name=PACKAGE_NAME,
@@ -13,5 +18,8 @@ setup(
     url="https://aprilweilab.github.io/",
     classifiers=[
         "Programming Language :: Python :: 3",
+    ],
+    install_requires=[
+        requirements,
     ],
 )


### PR DESCRIPTION
* The dependences in requirements.txt are auto-installed (or checked) when `pip install` is used.
* Add GitHub workflow for building packages in a variety of Python releases, run flake8 + formatting.