### PR TITLE
Reduce numpy/scipy versions required, so Python 3.9 works

### DIFF
--- a/grg_pheno_sim/__init__.py
+++ b/grg_pheno_sim/__init__.py
@@ -1,5 +1,5 @@
 """
-grg_pheno_sim is a phenotype simulator for GRGs, or Genotype Representation 
+grg_pheno_sim is a phenotype simulator for GRGs, or Genotype Representation
 Graphs
 
 =======

--- a/grg_pheno_sim/binary_phenotype.py
+++ b/grg_pheno_sim/binary_phenotype.py
@@ -1,5 +1,5 @@
 """
-This file simulates binary phenotypes on GRGs by using the usual simulation methods 
+This file simulates binary phenotypes on GRGs by using the usual simulation methods
 and then converting continuous phenotypes to binary phenotypes.
 =======
 """

--- a/grg_pheno_sim/model.py
+++ b/grg_pheno_sim/model.py
@@ -1,5 +1,5 @@
 """
-This file defines the distribution models used for causal mutation simulation. 
+This file defines the distribution models used for causal mutation simulation.
 =======
 """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=2.2.0
+numpy>=2.0.2
 pandas>=2.2.3
 pygrgl>=1.2
-scipy>=1.14.1
+scipy>=1.13.1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 import os
 
 PACKAGE_NAME = "grg_pheno_sim"
-VERSION = "1.0"
+VERSION = "1.1"
 
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(THISDIR, "requirements.txt")) as f:
@@ -20,6 +20,11 @@ setup(
     url="https://aprilweilab.github.io/",
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     install_requires=[
         requirements,


### PR DESCRIPTION
numpy and scipy have dropped support for Python 3.9 in more recent versions, and as far as I know we don't require specific functionality in the latest scipy/numpy.