### PR TITLE
Update API documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "doc/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+import sys
+import os
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "grg_pheno_sim"
+copyright = "2026, April Wei, Aditya Syam, Chris Adonizio"
+author = "Aditya Syam"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ["sphinx.ext.autodoc"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+
+# Nasty workaround for RTD being annoying to test with. There is probably a better
+# way to do this using .readthedocs.yaml
+thisdir = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(thisdir, ".."))

--- a/docs/grg_pheno_sim.rst
+++ b/docs/grg_pheno_sim.rst
@@ -1,0 +1,36 @@
+grg_pheno_sim API
+=================
+
+.. automodule:: grg_pheno_sim
+   :members:
+   :imported-members:
+   :undoc-members:
+   :show-inheritance:
+
+Phenotype Simulation
+--------------------
+
+.. automodule:: grg_pheno_sim.phenotype
+   :members: sim_phenotypes, add_covariates, convert_to_phen
+   :imported-members:
+   :undoc-members:
+   :show-inheritance:
+
+Binary Phenotype Simulation
+---------------------------
+
+.. automodule:: grg_pheno_sim.binary_phenotype
+   :members: sim_binary_phenotypes, sim_binary_phenotypes_custom
+   :imported-members:
+   :undoc-members:
+   :show-inheritance:
+
+Simulation with Multiple GRG Files
+----------------------------------
+
+.. automodule:: grg_pheno_sim.multi_grg_phenotype
+   :members: sim_phenotypes_multi_grg_ram, sim_phenotypes_multi_grg_sequential
+   :imported-members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,24 @@
+grg_pheno_sim Documentation
+===========================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   API Reference <grg_pheno_sim>
+
+``grg_pheno_sim`` simulates phenotypes on `GRGs (Genotype Representation Graphs) <https://grgl.readthedocs.io/en/stable/concepts.html>`_.
+The simulator first simulates effect sizes based on the user's desired distribution model (a wide spectrum of options are provided, both
+for simulation of single and multiple causal mutations at a go), computes the genetic values by passing the effect sizes down the GRG,
+and then adds simulated environmental noise to obtain the final phenotypes for the individuals in the graph. Normalization of genetic
+values is provided as well, either prior to adding environmental noise or after noise is added, according to the user's desire. In
+addition, there is an option to use normalized genotypes. The simulator offers the simulation of binary phenotypes as well, in addition
+to simulation on multiple GRGs simultaneously. Finally, options to obtain standardized outputs for both effect sizes (.par files) and
+phenotypes (.phen files) are included as well.
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+pygrgl
+scipy

--- a/grg_pheno_sim/binary_phenotype.py
+++ b/grg_pheno_sim/binary_phenotype.py
@@ -47,49 +47,46 @@ def sim_binary_phenotypes(
     Since the function simulates binary phenotypes, we add a Gaussian threshold check
     at the very end to convert continuous values to binary values.
 
-    Parameters
-    ----------
-    grg: The GRG on which phenotypes will be simulated.
-    model: The distribution model from which effect sizes are drawn. Depends on the
-    user's discretion.
-    num_causal: Number of causal sites simulated.
-    population_prevalence: The prevalence of the condition in the general population.
-    0.1 means 1 in 10 individuals have the condition.
-    random_seed: The random seed used for causal mutation effect simulation.
-    normalize_genetic_values_before_noise: Checks whether to normalize the genetic
-    values prior to simulating environmental noise (True if yes). Depends on the
-    user's discretion. Set to False by default.
-    heritability: Takes in the h2 features to simulate environmental noise
-    (set to None if the user prefers user-defined noise) and 1 is the user wants
-    zero noise.
-    user_mean: Mean parameter used for simulating environmental
-    noise taken in from the user.
-    user_cov: Covariance parameter used for simulating environmental
-    noise taken in from the user.
-    normalize_genetic_values_after: In the case where the h2 feature is not used,
-    this checks whether the user wants genetic values normalized at the end (True
-    if yes). Set to False by default.
-    save_effect_output: This boolean parameter decides whether the effect sizes
-    will be saved to a .par file using the standard output format. Default value is False.
-    effect_path: This parameter contains the path at which the .par output file will be saved.
-    Default value is None.
-    standardized_output: This boolean parameter decides whether the phenotypes
-    will be saved to a .phen file using the standard output format. Default value is False.
-    path: This parameter contains the path at which the .phen output file will be saved.
-    Default value is None.
-    header: This boolean parameter decides whether the .phen output file contains column
-    headers or not. Default value is False.
-    standardized: This boolean parameters decides whether the simulation uses standardized genotypes.
+    :param grg: The GRG on which phenotypes will be simulated.
+    :type grg: pygrgl.GRG
+    :param model: The distribution model from which effect sizes are drawn. Depends on the
+        user's discretion.
+    :param num_causal: Number of causal sites simulated.
+    :param population_prevalence: The prevalence of the condition in the general population.
+        0.1 means 1 in 10 individuals have the condition.
+    :param random_seed: The random seed used for causal mutation effect simulation.
+    :param normalize_genetic_values_before_noise: Checks whether to normalize the genetic
+        values prior to simulating environmental noise (True if yes). Depends on the
+        user's discretion. Default: False.
+    :param heritability: Takes in the h2 features to simulate environmental noise
+        (set to None if the user prefers user-defined noise) and 1 is the user wants
+        zero noise.
+    :param user_mean: Mean parameter used for simulating environmental
+        noise taken in from the user.
+    :param user_cov: Covariance parameter used for simulating environmental
+        noise taken in from the user.
+    :param normalize_genetic_values_after: In the case where the h2 feature is not used,
+        this checks whether the user wants genetic values normalized at the end (True
+        if yes). Default: False.
+    :param save_effect_output: This boolean parameter decides whether the effect sizes
+        will be saved to a .par file using the standard output format. Default value is False.
+    :param effect_path: This parameter contains the path at which the .par output file will be saved.
+        Default: None.
+    :param standardized_output: This boolean parameter decides whether the phenotypes
+        will be saved to a .phen file using the standard output format. Default value is False.
+    :param path: This parameter contains the path at which the .phen output file will be saved.
+        Default: None.
+    :param header: This boolean parameter decides whether the .phen output file contains column
+        headers or not. Default: False.
+    :param standardized: This boolean parameters decides whether the simulation uses standardized genotypes.
 
+    :return: Pandas dataframe with resultant binary phenotypes. The dataframe contains the following:
 
-    Returns
-    --------------------
-    Pandas dataframe with resultant binary phenotypes. The dataframe contains the following:
-    `causal_mutation_id`
-    `individual_id`
-    `genetic_value`
-    `environmental_noise`
-    `phenotype`
+        * `causal_mutation_id`
+        * `individual_id`
+        * `genetic_value`
+        * `environmental_noise`
+        * `phenotype`
     """
     if standardized:
         return sim_binary_phenotypes_standOp(
@@ -189,42 +186,40 @@ def sim_binary_phenotypes_custom(
     Since the function simulates binary phenotypes, we add a Gaussian threshold check
     at the very end to convert continuous values to binary values.
 
-    Parameters
-    ----------
-    grg: The GRG on which phenotypes will be simulated.
-    input_effects: The custom effect sizes dataset.
-    population_prevalence: The prevalence of the condition in the general population.
-    0.1 means 1 in 10 individuals have the condition.
-    normalize_genetic_values_before_noise: Checks whether to normalize the genetic
-    values prior to simulating environmental noise (True if yes). Depends on the
-    user's discretion. Set to False by default.
-    heritability: Takes in the h2 features to simulate environmental noise
-    (set to None if the user prefers user-defined noise) and 1 is the user wants
-    zero noise.
-    user_defined_noise_parameters: Parameters used for simulating environmental
-    noise taken in from the user.
-    normalize_genetic_values_after: In the case where the h2 feature is not used,
-    this checks whether the user wants genetic values normalized at the end (True
-    if yes). Set to False by default.
-    save_effect_output: This boolean parameter decides whether the effect sizes
-    will be saved to a .par file using the standard output format. Default value is False.
-    effect_path: This parameter contains the path at which the .par output file
-    will be saved. Default value is None.
-    standardized_output: This boolean parameter decides whether the phenotypes
-    will be saved to a .phen file using the standard output format. Default value is False.
-    path: This parameter contains the path at which the .phen output file will be saved.
-    Default value is None.
-    header: This boolean parameter decides whether the .phen output file contains column
-    headers or not. Default value is False.
+    :param grg: The GRG on which phenotypes will be simulated.
+    :type grg: pygrgl.GRG
+    :param input_effects: The custom effect sizes dataset.
+    :param population_prevalence: The prevalence of the condition in the general population.
+        0.1 means 1 in 10 individuals have the condition.
+    :param normalize_genetic_values_before_noise: Checks whether to normalize the genetic
+        values prior to simulating environmental noise (True if yes). Depends on the
+        user's discretion. Default: False.
+    :param heritability: Takes in the h2 features to simulate environmental noise
+        (set to None if the user prefers user-defined noise) and 1 is the user wants
+        zero noise.
+    :param user_defined_noise_parameters: Parameters used for simulating environmental
+        noise taken in from the user.
+    :param normalize_genetic_values_after: In the case where the h2 feature is not used,
+        this checks whether the user wants genetic values normalized at the end (True
+        if yes). Default: False.
+    :param save_effect_output: This boolean parameter decides whether the effect sizes
+        will be saved to a .par file using the standard output format. Default: False.
+    :param effect_path: This parameter contains the path at which the .par output file
+        will be saved. Default: None.
+    :param standardized_output: This boolean parameter decides whether the phenotypes
+        will be saved to a .phen file using the standard output format. Default: False.
+    :param path: This parameter contains the path at which the .phen output file will be saved.
+        Default: None.
+    :param header: This boolean parameter decides whether the .phen output file contains column
+        headers or not. Default: False.
 
-    Returns
-    --------------------
-    Pandas dataframe with resultant binary phenotypes. The dataframe contains the following:
-    `causal_mutation_id`
-    `individual_id`
-    `genetic_value`
-    `environmental_noise`
-    `phenotype`
+    :return: Pandas dataframe with resultant binary phenotypes. The dataframe contains the following:
+
+        * `causal_mutation_id`
+        * `individual_id`
+        * `genetic_value`
+        * `environmental_noise`
+        * `phenotype`
     """
     if standardized:
         return sim_binary_phenotypes_custom_stdOp(

--- a/grg_pheno_sim/multi_grg_phenotype.py
+++ b/grg_pheno_sim/multi_grg_phenotype.py
@@ -1,6 +1,5 @@
 """
-This file simulates phenotypes on multiple GRGs by using the usual simulation methods.
-=======
+This module simulates phenotypes on multiple GRGs by using the usual simulation methods.
 """
 
 import numpy as np
@@ -75,27 +74,32 @@ def sim_phenotypes_multi_grg_ram(
     """
     Simulate phenotypes by loading all GRGs into RAM simultaneously.
 
-    Parameters
-    ----------
-    grg_files : List of paths to GRG files to be processed.
-    model: The distribution model from which effect sizes are drawn. Depends on the user's discretion.
-    num_causal_per_file: Number of causal sites simulated for each file (same for each GRG).
-    random_seed: The random seed used for causal mutation simulation.
-    normalize_phenotype: Checks whether to normalize the phenotypes. The default value is False.
-    normalize_genetic_values_before_noise: Checks whether to normalize the genetic values prior to simulating environmental noise (True if yes). Depends on the user's discretion. Set to False by default.
-    heritability: Takes in the h2 features to simulate environmental noise (set to None if the user prefers user-defined noise) and 1 is the user wants zero noise.
-    user_defined_noise_parameters: Parameters used for simulating environmental noise taken in from the user.
-    normalize_genetic_values_after: In the case where the h2 feature is not used, this checks whether the user wants genetic values normalized at the end (True if yes). Set to False by default.
-    save_effect_output: This boolean parameter decides whether the effect sizes
-    will be saved to a .par file using the standard output format. Default value is False.
-    effect_path: This parameter contains the path at which the .par output file will be saved.
-    Default value is None.
-    standardized_output: This boolean parameter decides whether the phenotypes
-    will be saved to a .phen file using the standard output format. Default value is False.
-    path: This parameter contains the path at which the .phen output file will be saved.
-    Default value is None.
-    header: This boolean parameter decides whether the .phen output file contains column
-    headers or not. Default value is False.
+    :param grg_files: List of paths to GRG files to be processed.
+    :type grg_files: List[str]
+    :param model: The distribution model from which effect sizes are drawn. Depends on the user's discretion.
+    :param num_causal_per_file: Number of causal sites simulated for each file (same for each GRG).
+    :param random_seed: The random seed used for causal mutation simulation.
+    :param normalize_phenotype: Checks whether to normalize the phenotypes. Default: False.
+    :param normalize_genetic_values_before_noise: Checks whether to normalize the genetic values
+        prior to simulating environmental noise (True if yes). Depends on the user's discretion.
+        Default: False.
+    :param heritability: Takes in the h2 features to simulate environmental noise (set to None
+        if the user prefers user-defined noise) and 1 is the user wants zero noise.
+    :param user_defined_noise_parameters: Parameters used for simulating environmental noise
+        taken in from the user.
+    :param normalize_genetic_values_after: In the case where the h2 feature is not used, this
+        checks whether the user wants genetic values normalized at the end (True if yes).
+        Default: False.
+    :param save_effect_output: This boolean parameter decides whether the effect sizes
+        will be saved to a .par file using the standard output format. Default: False.
+    :param effect_path: This parameter contains the path at which the .par output file will be saved.
+        Default: None.
+    :param standardized_output: This boolean parameter decides whether the phenotypes
+        will be saved to a .phen file using the standard output format. Default: False.
+    :param path: This parameter contains the path at which the .phen output file will be saved.
+        Default: None.
+    :param header: This boolean parameter decides whether the .phen output file contains column
+        headers or not. Default value is False.
     """
     # Load all GRGs
     all_grgs = []
@@ -203,27 +207,32 @@ def sim_phenotypes_multi_grg_sequential(
     """
     Simulate phenotypes by processing GRGs sequentially to reduce memory usage.
 
-    Parameters
-    ----------
-    grg_files : List of paths to GRG files to be processed
-    model: The distribution model from which effect sizes are drawn. Depends on the user's discretion.
-    num_causal_per_file: Number of causal sites simulated for each file (same for each GRG).
-    random_seed: The random seed used for causal mutation simulation.
-    normalize_phenotype: Checks whether to normalize the phenotypes. The default value is False.
-    normalize_genetic_values_before_noise: Checks whether to normalize the genetic values prior to simulating environmental noise (True if yes). Depends on the user's discretion. Set to False by default.
-    heritability: Takes in the h2 features to simulate environmental noise (set to None if the user prefers user-defined noise) and 1 is the user wants zero noise.
-    user_defined_noise_parameters: Parameters used for simulating environmental noise taken in from the user.
-    normalize_genetic_values_after: In the case where the h2 feature is not used, this checks whether the user wants genetic values normalized at the end (True if yes). Set to False by default.
-    save_effect_output: This boolean parameter decides whether the effect sizes
-    will be saved to a .par file using the standard output format. Default value is False.
-    effect_path: This parameter contains the path at which the .par output file will be saved.
-    Default value is None.
-    standardized_output: This boolean parameter decides whether the phenotypes
-    will be saved to a .phen file using the standard output format. Default value is False.
-    path: This parameter contains the path at which the .phen output file will be saved.
-    Default value is None.
-    header: This boolean parameter decides whether the .phen output file contains column
-    headers or not. Default value is False.
+    :param grg_files: List of paths to GRG files to be processed
+    :type grg_files: List[str]
+    :param model: The distribution model from which effect sizes are drawn. Depends on the user's discretion.
+    :param num_causal_per_file: Number of causal sites simulated for each file (same for each GRG).
+    :param random_seed: The random seed used for causal mutation simulation.
+    :param normalize_phenotype: Checks whether to normalize the phenotypes. Default: False.
+    :param normalize_genetic_values_before_noise: Checks whether to normalize the genetic values prior
+        to simulating environmental noise (True if yes). Depends on the user's discretion.
+        Default: False.
+    :param heritability: Takes in the h2 features to simulate environmental noise (set to None if
+        the user prefers user-defined noise) and 1 is the user wants zero noise.
+    :param user_defined_noise_parameters: Parameters used for simulating environmental noise taken
+        in from the user.
+    :param normalize_genetic_values_after: In the case where the h2 feature is not used, this
+        checks whether the user wants genetic values normalized at the end (True if yes).
+        Default: False.
+    :param save_effect_output: This boolean parameter decides whether the effect sizes
+        will be saved to a .par file using the standard output format. Default value is False.
+    :param effect_path: This parameter contains the path at which the .par output file will be
+        saved. Default: None.
+    :param standardized_output: This boolean parameter decides whether the phenotypes
+        will be saved to a .phen file using the standard output format. Default: False.
+    :param path: This parameter contains the path at which the .phen output file will be saved.
+        Default: None.
+    :param header: This boolean parameter decides whether the .phen output file contains column
+        headers or not. Default: False.
     """
 
     all_genetic_values = []

--- a/grg_pheno_sim/phenotype.py
+++ b/grg_pheno_sim/phenotype.py
@@ -1,6 +1,5 @@
 """
 This file simulates the phenotypes overall by combining the incremental stages of simulation on GRGs.
-=======
 """
 
 import pandas as pd
@@ -35,12 +34,10 @@ def convert_to_phen(phenotypes_df, path, include_header=False):
     """
     This function converts the phenotypes dataframe to a CSV file.
 
-    Parameters
-    ----------
-    phenotypes_df: The input pandas dataframe containing the phenotypes.
-    path: The path at which the CSV file will be saved.
-    include_header: A boolean parameter that indicates whether headers have to be included.
-    Default value is False.
+    :param phenotypes_df: The input pandas dataframe containing the phenotypes.
+    :param path: The path at which the CSV file will be saved.
+    :param include_header: A boolean parameter that indicates whether headers have to be
+        included. Default: False.
     """
     if path is None:
         raise ValueError("Output path must be defined")
@@ -73,38 +70,43 @@ def sim_phenotypes(
     """
     Function to simulate phenotypes in one go by combining all intermittent stages.
 
-    Parameters
-    ----------
-    grg: The GRG on which phenotypes will be simulated.
-    model: The distribution model from which effect sizes are drawn. Depends on the user's discretion.
-    Default model used is the standard Gaussian.
-    num_causal: Number of causal sites simulated. Default value used is num_mutations.
-    random_seed: The random seed used for causal mutation simulation. Default values is 42.
-    normalize_phenotype: Checks whether to normalize the phenotypes. The default value is False.
-    normalize_genetic_values_before_noise: Checks whether to normalize the genetic values prior to simulating environmental noise (True if yes). Depends on the user's discretion. Set to False by default.
-    heritability: Takes in the h2 features to simulate environmental noise (set to None if the user prefers user-defined noise) and 1 is the user wants zero noise.
-    user_defined_noise_parameters: Parameters used for simulating environmental noise taken in from the user.
-    normalize_genetic_values_after: In the case where the h2 feature is not used, this checks whether the user wants genetic values normalized at the end (True if yes). Set to False by default.
-    save_effect_output: This boolean parameter decides whether the effect sizes
-    will be saved to a .par file using the standard output format. Default value is False.
-    effect_path: This parameter contains the path at which the .par output file will be saved.
-    Default value is None.
-    standardized_output: This boolean parameter decides whether the phenotypes
-    will be saved to a .phen file using the standard output format. Default value is False.
-    path: This parameter contains the path at which the .phen output file will be saved.
-    Default value is None.
-    header: This boolean parameter decides whether the .phen output file contains column
-    headers or not. Default value is False.
-    standardized: This boolean parameters decides whether the simulation uses standardized genotypes.
+    :param grg: The GRG on which phenotypes will be simulated.
+    :type grg: pygrgl.GRG
+    :param model: The distribution model from which effect sizes are drawn. Depends on the
+        user's discretion. Default model used is the standard Gaussian.
+    :param num_causal: Number of causal sites simulated. Default value used is num_mutations.
+    :param random_seed: The random seed used for causal mutation simulation. Default: 42.
+    :param normalize_phenotype: Checks whether to normalize the phenotypes. Default: False.
+    :param normalize_genetic_values_before_noise: Checks whether to normalize the genetic
+        values prior to simulating environmental noise (True if yes). Depends on the user's
+        discretion. Default: False.
+    :param heritability: Takes in the h2 features to simulate environmental noise (set to
+        None if the user prefers user-defined noise) and 1 is the user wants zero noise.
+    :param user_defined_noise_parameters: Parameters used for simulating environmental noise
+        taken in from the user.
+    :param normalize_genetic_values_after: In the case where the h2 feature is not used, this
+        checks whether the user wants genetic values normalized at the end (True if yes).
+        Default: False.
+    :param save_effect_output: This boolean parameter decides whether the effect sizes
+        will be saved to a .par file using the standard output format. Default: False.
+    :param effect_path: This parameter contains the path at which the .par output file will
+        be saved. Default: None.
+    :param standardized_output: This boolean parameter decides whether the phenotypes
+        will be saved to a .phen file using the standard output format. Default: False.
+    :param path: This parameter contains the path at which the .phen output file will be saved.
+        Default: None.
+    :param header: This boolean parameter decides whether the .phen output file contains column
+        headers or not. Default: False.
+    :param standardized: This boolean parameters decides whether the simulation uses standardized
+        genotypes.
 
-    Returns
-    --------------------
-    Pandas dataframe with resultant phenotypes. The dataframe contains the following:
-    `causal_mutation_id`
-    `individual_id`
-    `genetic_value`
-    `environmental_noise`
-    `phenotype`
+    :return: Pandas dataframe with resultant phenotypes. The dataframe contains the following:
+
+        * `causal_mutation_id`
+        * `individual_id`
+        * `genetic_value`
+        * `environmental_noise`
+        * `phenotype`
     """
 
     if standardized is True:
@@ -573,33 +575,27 @@ def add_covariates(
     Wrapper around sim_phenotypes that adds covariate effects:
         Y = genetic_value + covariate_value + environmental_noise
 
-    Parameters
-    ----------
-    grg : pygrgl GRG
-        The GRG used for phenotype simulation.
+    :param grg: The GRG used for phenotype simulation.
+    :type grg: pygrgl.GRG
+    :param covariates: Covariate matrix C.
 
-    covariates : pandas.DataFrame or numpy.ndarray
-        Covariate matrix C.
         - If DataFrame:
             * Must have one row per individual.
             * If it includes 'individual_id', merge is done by ID.
             * Otherwise, row order must match sim_phenotypes output.
         - If ndarray:
             * Shape (n_individuals, n_covariates), row order matches phenotypes.
-
-    cov_effects : array-like
-        Coefficient vector α (length must equal number of covariates).
-
-    **sim_kwargs :
-        Keyword arguments passed directly to sim_phenotypes
+    :type covariates: Union[pandas.DataFrame, numpy.ndarray]
+    :param cov_effects: Coefficient vector α (length must equal number of covariates).
+    :type cov_effects: numpy.typing.ArrayLike
+    :param sim_kwargs: Keyword arguments passed directly to sim_phenotypes
         (heritability, num_causal, normalize_phenotype, etc.).
 
-    Returns
-    -------
-    final_phenotypes : pandas.DataFrame
-        Same as sim_phenotypes output with two new columns:
-            - covariate_value
-            - phenotype (updated)
+    :return: Same as sim_phenotypes output with two new columns:
+
+        - covariate_value
+        - phenotype (updated)
+    :rtype: pandas.DataFrame
     """
 
     # 1. Run original phenotype simulation


### PR DESCRIPTION
Generate Sphinx docs for the "core" API methods, and switchover those methods to use the Python/Sphinx style of method documentation which formats parameter/type information for you.